### PR TITLE
Correctly parse password using regex

### DIFF
--- a/js/exp9.js
+++ b/js/exp9.js
@@ -2,7 +2,7 @@ function validateForm() {
     var x = document.forms["myForm"]["username"].value;
 	var y = document.forms["myForm"]["pass"].value;
 	var z = document.forms["myForm"]["mobileno"].value;
-	var regex = /^(?=.*[a-z])(?=.*[A-Z])$/;
+	var regex = /(?=.*[a-z])(?=.*[A-Z])/;
 	var n = z.length;
     if (x == "") {
         alert("Name must be filled out");
@@ -23,7 +23,7 @@ function validateForm() {
 	}else if((n<10)||(n>10)){
 		alert("Mobile number should be of 10 digits");
 		return false;
-	}else if(y.value.match(regex)){
+	}else if(regex.test(y) == false){
 		alert("The password should contain atleast 1 uppercase and 1 lowercase character");
 		return false;
 	}


### PR DESCRIPTION
- The current implementation accepts passwords in ALL CAPS and hence
  wrong.
- Use test() provided by JS, because it works.
- Remove $ and ^ used in multiline cases and useless in password
  context.